### PR TITLE
Fix for EBS stop/start

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ gem 'thor-foodcritic'
 gem 'thor-scmversion'
 
 group :integration do
-  gem 'test-kitchen', '~> 1.2.0'
+  gem 'test-kitchen', '~> 1.2.1'
   gem 'kitchen-vagrant'
   gem 'strainer', '~> 3.3.0'
-  gem 'chefspec', '~> 3.0.2'
+  gem 'chefspec', '~> 3.4.0'
   gem 'travis-lint'
 end

--- a/recipes/swap.rb
+++ b/recipes/swap.rb
@@ -34,8 +34,5 @@ end
 swap_file node['rs-base']['swap']['file'] do
   # The swap cookbook expects the size to be in MB. So convert the size in GB to MB.
   size node['rs-base']['swap']['size'].to_i * 1024
-  persist true
   action :create
 end
-
-#TODO deal with collectd

--- a/test/integration/swap/bats/swap.bats
+++ b/test/integration/swap/bats/swap.bats
@@ -14,6 +14,6 @@ SWAPFILE="/mnt/ephemeral/swapfile"
   swapon -s | grep $SWAPFILE
 }
 
-@test "Swap is in fstab." {
-  grep $SWAPFILE /etc/fstab
+@test "Swap is not in fstab." {
+  ! grep $SWAPFILE /etc/fstab
 }


### PR DESCRIPTION
- Do not persist swap file to /etc/fstab since ephemeral volumes are
  ephemeral and will not come back after stop/start.
