### PR TITLE
The collectd plugin for swap is not installed

### DIFF
--- a/recipes/collectd.rb
+++ b/recipes/collectd.rb
@@ -43,6 +43,7 @@ collectd_plugin 'df' do
 end
 collectd_plugin 'disk'
 collectd_plugin 'memory'
+collectd_plugin 'swap'
 collectd_plugin 'load'
 collectd_plugin 'processes'
 collectd_plugin 'users'

--- a/test/integration/collectd/bats/collectd.bats
+++ b/test/integration/collectd/bats/collectd.bats
@@ -28,7 +28,7 @@ esac
 }
 
 @test "plugin config files exist" {
-  for CONF in cpu.conf df.conf load.conf disk.conf memory.conf processes.conf users.conf; do
+  for CONF in cpu.conf df.conf load.conf disk.conf memory.conf swap.conf processes.conf users.conf; do
     test -f $PLUGIN_CONF_DIR/$CONF
   done
 }


### PR DESCRIPTION
Either the `rs-base::collectd` recipe or the `rs-base::swap` recipe should install the swap collectd plugin so we can get the swap graphs in the RightScale dashboard and also use the swap value to trigger alerts when the system starts using swap.
